### PR TITLE
Style changes sggested by shellcheck

### DIFF
--- a/comnet-install.sh
+++ b/comnet-install.sh
@@ -30,7 +30,7 @@ fi
 
 read -p " How many Gb do you want to allocate to your vault? [5Gb]: " GB_ALLOCATED
 VAULT_SIZE=${GB_ALLOCATED:-5}
-echo $VAULT_SIZE "Gb will be allocated for storing chunks"
+echo "$VAULT_SIZE" "Gb will be allocated for storing chunks"
 echo "_________________________________________________________"
 
 sudo apt -qq update >/dev/null
@@ -39,9 +39,9 @@ sudo snap install curl
 
 PATH=$PATH:/$HOME/.safe/cli:$HOME/.cargo/bin 
 
-ACTIVE_IF=$((cd /sys/class/net; echo *)|awk '{print $1;}')
-LOCAL_IP=$(echo `ifdata -pa $ACTIVE_IF`)
-PUBLIC_IP=$(echo `curl -s ifconfig.me`)
+ACTIVE_IF=$( ( cd /sys/class/net || exit; echo *)|awk '{print $1;}')
+LOCAL_IP=$(echo $(ifdata -pa "$ACTIVE_IF"))
+PUBLIC_IP=$(echo $(curl -s ifconfig.me))
 SAFE_PORT=12000
 SAFENET=folaht
 CONFIG_URL=https://link.tardigradeshare.io/s/julx763rsy2egbnj2nixoahpobgq/rezosur/koqfig/sjefolaht_node_connection_info.config?wrap=0
@@ -52,13 +52,13 @@ SN_CLI_QUERY_TIMEOUT=3600
 
 # Install Safe software and configuration
 
-rm -rf $HOME/.safe # clear out any old files
+rm -rf "$HOME"/.safe # clear out any old files
 
 #get the CLI
 curl -so- https://raw.githubusercontent.com/maidsafe/safe_network/master/resources/scripts/install.sh | bash
 echo $(safe --version) "install complete"
 
-safe networks add $SAFENET $CONFIG_URL
+safe networks add $SAFENET "$CONFIG_URL"
 safe networks switch $SAFENET
 safe networks
 sleep 2
@@ -73,18 +73,18 @@ echo "SAFE Node install completed"
 echo "Attempting to join the '$SAFENET' network using the following parameters"
 echo ""
 echo "--max-capacity" $VAULT_SIZE
-echo "--local-addr" $LOCAL_IP":"$SAFE_PORT
-echo "--public-addr" $PUBLIC_IP":"$SAFE_PORT
-echo "--log-dir" $LOG_DIR
+echo "--local-addr" "$LOCAL_IP"":"$SAFE_PORT
+echo "--public-addr" "$PUBLIC_IP"":"$SAFE_PORT
+echo "--log-dir" "$LOG_DIR"
 echo "--skip-auto-port-forwarding"
 
 RUST_LOG=safe_network=trace,qp2p=info \
     ~/.safe/node/sn_node \
     --max-capacity $VAULT_SIZE \
-    --local-addr $LOCAL_IP:$SAFE_PORT \
-    --public-addr $PUBLIC_IP:$SAFE_PORT \
+    --local-addr "$LOCAL_IP":$SAFE_PORT \
+    --public-addr "$PUBLIC_IP":$SAFE_PORT \
     --skip-auto-port-forwarding \
-    --log-dir $LOG_DIR    
+    --log-dir "$LOG_DIR"    
 
 #clear
 echo "_____________________________________________________________________________________________________"
@@ -102,5 +102,4 @@ sleep 3
 sudo snap install rustup --classic
 rustup toolchain install stable
 cargo install vdash
-vdash $LOG_DIR/sn_node.log
-
+vdash "$LOG_DIR"/sn_node.log

--- a/comnet-install.sh
+++ b/comnet-install.sh
@@ -19,7 +19,7 @@ echo "installed to display network and node information"
 echo ""
 echo ""
 echo "OK to proceed [y,N]"
-read input
+read -r input
 
 if [[ $input == "Y" || $input == "y" ]]; then
         echo "OK then, let's go."
@@ -28,7 +28,7 @@ else
        exit
 fi
 
-read -p " How many Gb do you want to allocate to your vault? [5Gb]: " GB_ALLOCATED
+read -p -r " How many Gb do you want to allocate to your vault? [5Gb]: " GB_ALLOCATED
 VAULT_SIZE=${GB_ALLOCATED:-5}
 echo "$VAULT_SIZE" "Gb will be allocated for storing chunks"
 echo "_________________________________________________________"


### PR DESCRIPTION
shelcheck.txt

 shellcheck myscript
 
Line 22:
read input
^-- SC2162 (info): read without -r will mangle backslashes.
 
Line 31:
read -p " How many Gb do you want to allocate to your vault? [5Gb]: " GB_ALLOCATED
^-- SC2162 (info): read without -r will mangle backslashes.
 
Line 33:
echo $VAULT_SIZE "Gb will be allocated for storing chunks"
     ^-- SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: (apply this, apply all SC2086)
echo "$VAULT_SIZE" "Gb will be allocated for storing chunks"
 
Line 42:
ACTIVE_IF=$((cd /sys/class/net; echo *)|awk '{print $1;}')
          ^-- SC1102 (error): Shells disambiguate $(( differently or not at all. For $(command substitution), add space after $( . For $((arithmetics)), fix parsing errors.
             ^-- SC2164 (warning): Use 'cd ... || exit' or 'cd ... || return' in case cd fails.

Did you mean: (apply this, apply all SC2164)
ACTIVE_IF=$((cd /sys/class/net || exit; echo *)|awk '{print $1;}')
 
Line 43:
LOCAL_IP=$(echo `ifdata -pa $ACTIVE_IF`)
                ^-- SC2046 (warning): Quote this to prevent word splitting.
                ^-- SC2005 (style): Useless echo? Instead of 'echo $(cmd)', just use 'cmd'.
                ^-- SC2006 (style): Use $(...) notation instead of legacy backticks `...`.
                            ^-- SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: (apply this, apply all SC2006, apply all SC2086)
LOCAL_IP=$(echo $(ifdata -pa "$ACTIVE_IF"))
 
Line 44:
PUBLIC_IP=$(echo `curl -s ifconfig.me`)
                 ^-- SC2046 (warning): Quote this to prevent word splitting.
                 ^-- SC2005 (style): Useless echo? Instead of 'echo $(cmd)', just use 'cmd'.
                 ^-- SC2006 (style): Use $(...) notation instead of legacy backticks `...`.

Did you mean: (apply this, apply all SC2006)
PUBLIC_IP=$(echo $(curl -s ifconfig.me))
 
Line 47:
CONFIG_URL=https://link.tardigradeshare.io/s/julx763rsy2egbnj2nixoahpobgq/rezosur/koqfig/sjefolaht_node_connection_info.config?wrap=0
           ^-- SC2125 (warning): Brace expansions and globs are literal in assignments. Quote it or use an array.
 
Line 49:
VAULT_SIZE=$((1024*1024*1024*$GB_ALLOCATED))
                             ^-- SC2004 (style): $/${} is unnecessary on arithmetic variables.
 
Line 51:
SN_CLI_QUERY_TIMEOUT=3600
^-- SC2034 (warning): SN_CLI_QUERY_TIMEOUT appears unused. Verify use (or export if used externally).
 
Line 55:
rm -rf $HOME/.safe # clear out any old files
       ^-- SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: (apply this, apply all SC2086)
rm -rf "$HOME"/.safe # clear out any old files
 
Line 59:
echo $(safe --version) "install complete"
     ^-- SC2046 (warning): Quote this to prevent word splitting.
 
Line 61:
safe networks add $SAFENET $CONFIG_URL
                           ^-- SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: (apply this, apply all SC2086)
safe networks add $SAFENET "$CONFIG_URL"
 
Line 66:
echo $(safe node bin-version) "install complete"
     ^-- SC2046 (warning): Quote this to prevent word splitting.
 
Line 76:
echo "--local-addr" $LOCAL_IP":"$SAFE_PORT
                    ^-- SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: (apply this, apply all SC2086)
echo "--local-addr" "$LOCAL_IP"":"$SAFE_PORT
 
Line 77:
echo "--public-addr" $PUBLIC_IP":"$SAFE_PORT
                     ^-- SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: (apply this, apply all SC2086)
echo "--public-addr" "$PUBLIC_IP"":"$SAFE_PORT
 
Line 78:
echo "--log-dir" $LOG_DIR
                 ^-- SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: (apply this, apply all SC2086)
echo "--log-dir" "$LOG_DIR"
 
Line 84:
    --local-addr $LOCAL_IP:$SAFE_PORT \
                 ^-- SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: (apply this, apply all SC2086)
    --local-addr "$LOCAL_IP":$SAFE_PORT \
 
Line 85:
    --public-addr $PUBLIC_IP:$SAFE_PORT \
                  ^-- SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: (apply this, apply all SC2086)
    --public-addr "$PUBLIC_IP":$SAFE_PORT \
 
Line 87:
    --log-dir $LOG_DIR    
              ^-- SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: (apply this, apply all SC2086)
    --log-dir "$LOG_DIR"    
 
Line 105:
vdash $LOG_DIR/sn_node.log
      ^-- SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: (apply this, apply all SC2086)
vdash "$LOG_DIR"/sn_node.log