### PR TITLE
Add files via upload

### DIFF
--- a/shellcheck.txt
+++ b/shellcheck.txt
@@ -1,0 +1,126 @@
+$ shellcheck myscript
+ 
+Line 22:
+read input
+^-- SC2162 (info): read without -r will mangle backslashes.
+ 
+Line 31:
+read -p " How many Gb do you want to allocate to your vault? [5Gb]: " GB_ALLOCATED
+^-- SC2162 (info): read without -r will mangle backslashes.
+ 
+Line 33:
+echo $VAULT_SIZE "Gb will be allocated for storing chunks"
+     ^-- SC2086 (info): Double quote to prevent globbing and word splitting.
+
+Did you mean: (apply this, apply all SC2086)
+echo "$VAULT_SIZE" "Gb will be allocated for storing chunks"
+ 
+Line 42:
+ACTIVE_IF=$((cd /sys/class/net; echo *)|awk '{print $1;}')
+          ^-- SC1102 (error): Shells disambiguate $(( differently or not at all. For $(command substitution), add space after $( . For $((arithmetics)), fix parsing errors.
+             ^-- SC2164 (warning): Use 'cd ... || exit' or 'cd ... || return' in case cd fails.
+
+Did you mean: (apply this, apply all SC2164)
+ACTIVE_IF=$((cd /sys/class/net || exit; echo *)|awk '{print $1;}')
+ 
+Line 43:
+LOCAL_IP=$(echo `ifdata -pa $ACTIVE_IF`)
+                ^-- SC2046 (warning): Quote this to prevent word splitting.
+                ^-- SC2005 (style): Useless echo? Instead of 'echo $(cmd)', just use 'cmd'.
+                ^-- SC2006 (style): Use $(...) notation instead of legacy backticks `...`.
+                            ^-- SC2086 (info): Double quote to prevent globbing and word splitting.
+
+Did you mean: (apply this, apply all SC2006, apply all SC2086)
+LOCAL_IP=$(echo $(ifdata -pa "$ACTIVE_IF"))
+ 
+Line 44:
+PUBLIC_IP=$(echo `curl -s ifconfig.me`)
+                 ^-- SC2046 (warning): Quote this to prevent word splitting.
+                 ^-- SC2005 (style): Useless echo? Instead of 'echo $(cmd)', just use 'cmd'.
+                 ^-- SC2006 (style): Use $(...) notation instead of legacy backticks `...`.
+
+Did you mean: (apply this, apply all SC2006)
+PUBLIC_IP=$(echo $(curl -s ifconfig.me))
+ 
+Line 47:
+CONFIG_URL=https://link.tardigradeshare.io/s/julx763rsy2egbnj2nixoahpobgq/rezosur/koqfig/sjefolaht_node_connection_info.config?wrap=0
+           ^-- SC2125 (warning): Brace expansions and globs are literal in assignments. Quote it or use an array.
+ 
+Line 49:
+VAULT_SIZE=$((1024*1024*1024*$GB_ALLOCATED))
+                             ^-- SC2004 (style): $/${} is unnecessary on arithmetic variables.
+ 
+Line 51:
+SN_CLI_QUERY_TIMEOUT=3600
+^-- SC2034 (warning): SN_CLI_QUERY_TIMEOUT appears unused. Verify use (or export if used externally).
+ 
+Line 55:
+rm -rf $HOME/.safe # clear out any old files
+       ^-- SC2086 (info): Double quote to prevent globbing and word splitting.
+
+Did you mean: (apply this, apply all SC2086)
+rm -rf "$HOME"/.safe # clear out any old files
+ 
+Line 59:
+echo $(safe --version) "install complete"
+     ^-- SC2046 (warning): Quote this to prevent word splitting.
+ 
+Line 61:
+safe networks add $SAFENET $CONFIG_URL
+                           ^-- SC2086 (info): Double quote to prevent globbing and word splitting.
+
+Did you mean: (apply this, apply all SC2086)
+safe networks add $SAFENET "$CONFIG_URL"
+ 
+Line 66:
+echo $(safe node bin-version) "install complete"
+     ^-- SC2046 (warning): Quote this to prevent word splitting.
+ 
+Line 76:
+echo "--local-addr" $LOCAL_IP":"$SAFE_PORT
+                    ^-- SC2086 (info): Double quote to prevent globbing and word splitting.
+
+Did you mean: (apply this, apply all SC2086)
+echo "--local-addr" "$LOCAL_IP"":"$SAFE_PORT
+ 
+Line 77:
+echo "--public-addr" $PUBLIC_IP":"$SAFE_PORT
+                     ^-- SC2086 (info): Double quote to prevent globbing and word splitting.
+
+Did you mean: (apply this, apply all SC2086)
+echo "--public-addr" "$PUBLIC_IP"":"$SAFE_PORT
+ 
+Line 78:
+echo "--log-dir" $LOG_DIR
+                 ^-- SC2086 (info): Double quote to prevent globbing and word splitting.
+
+Did you mean: (apply this, apply all SC2086)
+echo "--log-dir" "$LOG_DIR"
+ 
+Line 84:
+    --local-addr $LOCAL_IP:$SAFE_PORT \
+                 ^-- SC2086 (info): Double quote to prevent globbing and word splitting.
+
+Did you mean: (apply this, apply all SC2086)
+    --local-addr "$LOCAL_IP":$SAFE_PORT \
+ 
+Line 85:
+    --public-addr $PUBLIC_IP:$SAFE_PORT \
+                  ^-- SC2086 (info): Double quote to prevent globbing and word splitting.
+
+Did you mean: (apply this, apply all SC2086)
+    --public-addr "$PUBLIC_IP":$SAFE_PORT \
+ 
+Line 87:
+    --log-dir $LOG_DIR    
+              ^-- SC2086 (info): Double quote to prevent globbing and word splitting.
+
+Did you mean: (apply this, apply all SC2086)
+    --log-dir "$LOG_DIR"    
+ 
+Line 105:
+vdash $LOG_DIR/sn_node.log
+      ^-- SC2086 (info): Double quote to prevent globbing and word splitting.
+
+Did you mean: (apply this, apply all SC2086)
+vdash "$LOG_DIR"/sn_node.log


### PR DESCRIPTION
shellcheck style corrections

 shellcheck myscript
 
Line 22:
read input
^-- SC2162 (info): read without -r will mangle backslashes.
 
Line 31:
read -p " How many Gb do you want to allocate to your vault? [5Gb]: " GB_ALLOCATED
^-- SC2162 (info): read without -r will mangle backslashes.
 
Line 33:
echo $VAULT_SIZE "Gb will be allocated for storing chunks"
     ^-- SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: (apply this, apply all SC2086)
echo "$VAULT_SIZE" "Gb will be allocated for storing chunks"
 
Line 42:
ACTIVE_IF=$((cd /sys/class/net; echo *)|awk '{print $1;}')
          ^-- SC1102 (error): Shells disambiguate $(( differently or not at all. For $(command substitution), add space after $( . For $((arithmetics)), fix parsing errors.
             ^-- SC2164 (warning): Use 'cd ... || exit' or 'cd ... || return' in case cd fails.

Did you mean: (apply this, apply all SC2164)
ACTIVE_IF=$((cd /sys/class/net || exit; echo *)|awk '{print $1;}')
 
Line 43:
LOCAL_IP=$(echo `ifdata -pa $ACTIVE_IF`)
                ^-- SC2046 (warning): Quote this to prevent word splitting.
                ^-- SC2005 (style): Useless echo? Instead of 'echo $(cmd)', just use 'cmd'.
                ^-- SC2006 (style): Use $(...) notation instead of legacy backticks `...`.
                            ^-- SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: (apply this, apply all SC2006, apply all SC2086)
LOCAL_IP=$(echo $(ifdata -pa "$ACTIVE_IF"))
 
Line 44:
PUBLIC_IP=$(echo `curl -s ifconfig.me`)
                 ^-- SC2046 (warning): Quote this to prevent word splitting.
                 ^-- SC2005 (style): Useless echo? Instead of 'echo $(cmd)', just use 'cmd'.
                 ^-- SC2006 (style): Use $(...) notation instead of legacy backticks `...`.

Did you mean: (apply this, apply all SC2006)
PUBLIC_IP=$(echo $(curl -s ifconfig.me))
 
Line 47:
CONFIG_URL=https://link.tardigradeshare.io/s/julx763rsy2egbnj2nixoahpobgq/rezosur/koqfig/sjefolaht_node_connection_info.config?wrap=0
           ^-- SC2125 (warning): Brace expansions and globs are literal in assignments. Quote it or use an array.
 
Line 49:
VAULT_SIZE=$((1024*1024*1024*$GB_ALLOCATED))
                             ^-- SC2004 (style): $/${} is unnecessary on arithmetic variables.
 
Line 51:
SN_CLI_QUERY_TIMEOUT=3600
^-- SC2034 (warning): SN_CLI_QUERY_TIMEOUT appears unused. Verify use (or export if used externally).
 
Line 55:
rm -rf $HOME/.safe # clear out any old files
       ^-- SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: (apply this, apply all SC2086)
rm -rf "$HOME"/.safe # clear out any old files
 
Line 59:
echo $(safe --version) "install complete"
     ^-- SC2046 (warning): Quote this to prevent word splitting.
 
Line 61:
safe networks add $SAFENET $CONFIG_URL
                           ^-- SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: (apply this, apply all SC2086)
safe networks add $SAFENET "$CONFIG_URL"
 
Line 66:
echo $(safe node bin-version) "install complete"
     ^-- SC2046 (warning): Quote this to prevent word splitting.
 
Line 76:
echo "--local-addr" $LOCAL_IP":"$SAFE_PORT
                    ^-- SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: (apply this, apply all SC2086)
echo "--local-addr" "$LOCAL_IP"":"$SAFE_PORT
 
Line 77:
echo "--public-addr" $PUBLIC_IP":"$SAFE_PORT
                     ^-- SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: (apply this, apply all SC2086)
echo "--public-addr" "$PUBLIC_IP"":"$SAFE_PORT
 
Line 78:
echo "--log-dir" $LOG_DIR
                 ^-- SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: (apply this, apply all SC2086)
echo "--log-dir" "$LOG_DIR"
 
Line 84:
    --local-addr $LOCAL_IP:$SAFE_PORT \
                 ^-- SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: (apply this, apply all SC2086)
    --local-addr "$LOCAL_IP":$SAFE_PORT \
 
Line 85:
    --public-addr $PUBLIC_IP:$SAFE_PORT \
                  ^-- SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: (apply this, apply all SC2086)
    --public-addr "$PUBLIC_IP":$SAFE_PORT \
 
Line 87:
    --log-dir $LOG_DIR    
              ^-- SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: (apply this, apply all SC2086)
    --log-dir "$LOG_DIR"    
 
Line 105:
vdash $LOG_DIR/sn_node.log
      ^-- SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: (apply this, apply all SC2086)
vdash "$LOG_DIR"/sn_node.log
